### PR TITLE
atari800: Add version 4.2.0

### DIFF
--- a/bucket/atari800.json
+++ b/bucket/atari800.json
@@ -1,0 +1,24 @@
+{
+    "version": "4.2.0",
+    "description": "Portable and free Atari 8-bit emulator",
+    "homepage": "https://atari800.github.io",
+    "license": "GPL-2.0-only",
+    "url": "https://github.com/atari800/atari800/releases/download/ATARI800_4_2_0/atari800-4.2.0-win32-sdl.zip",
+    "hash": "1da32ab1e5812c8018168018b4dab652d38a989dc3cc78d7c54b6f80d585a08a",
+    "extract_dir": "atari800-4.2.0-win32-sdl",
+    "bin": "atari800.exe",
+    "shortcuts": [
+        [
+            "atari800.exe",
+            "Atari 800"
+        ]
+    ],
+    "checkver": {
+        "url": "https://atari800.github.io/news.html",
+        "regex": "Atari800 v([\\d.]+) released"
+    },
+    "autoupdate": {
+        "url": "https://github.com/atari800/atari800/releases/download/ATARI800_$underscoreVersion/atari800-$version-win32-sdl.zip",
+        "extract_dir": "atari800-$version-win32-sdl"
+    }
+}


### PR DESCRIPTION
Atari 800 emulator is a very popular Atari 8 bit computer emulator that is highly portable