### PR TITLE
prosystem: Add version 1.3

### DIFF
--- a/bucket/prosystem.json
+++ b/bucket/prosystem.json
@@ -13,7 +13,9 @@
             "ProSystem Atari 7800"
         ]
     ],
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/gstanton/ProSystem1_3"
+    },
     "autoupdate": {
         "url": "https://github.com/gstanton/ProSystem$underscoreVersion/releases/download/v$version/ProSystem_$underscoreVersion.zip",
         "extract_dir": "ProSystem_$cleanVersion"

--- a/bucket/prosystem.json
+++ b/bucket/prosystem.json
@@ -1,0 +1,21 @@
+{
+    "version": "1.3",
+    "description": "The ProSystem Emulator is an Atari 7800 emulator for the PC",
+    "homepage": "http://gstanton.github.io/ProSystem1_3",
+    "license": "GPL-2.0-only",
+    "url": "https://github.com/gstanton/ProSystem1_3/releases/download/v1.3/ProSystem_1_3.zip",
+    "hash": "34cfba00ee7f97bb49b26e08b874d36410569e861e24f7522523b0643b15b2be",
+    "extract_dir": "ProSystem_13",
+    "bin": "ProSystem.exe",
+    "shortcuts": [
+        [
+            "ProSystem.exe",
+            "ProSystem Atari 7800"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/gstanton/ProSystem$underscoreVersion/releases/download/v$version/ProSystem_$underscoreVersion.zip",
+        "extract_dir": "ProSystem_$cleanVersion"
+    }
+}


### PR DESCRIPTION
The ProSystem Emulator is an Atari 7800 emulator for the PC and Windows OS. The emulator was written in C++ using the Windows API and DirectX. It emulates the Atari 7800 NTSC and PAL TV standards. The emulator was originally written by Greg Stanton and then updated by others.