### PR TITLE
saint: Add version 2.40

### DIFF
--- a/bucket/saint.json
+++ b/bucket/saint.json
@@ -2,7 +2,7 @@
     "version": "2.40",
     "description": "SainT is a Windows based cycle accurate ATARI-ST emulator",
     "homepage": "http://leonard.oxg.free.fr/SainT/saint.html",
-    "license": "",
+    "license": "Freeware",
     "url": "http://leonard.oxg.free.fr/SainT/SainT240.zip",
     "hash": "a30c15f485bcc7ada635a5eb1654ff5cf805da8d141a1b64d4e83a26d609b0fa",
     "extract_dir": "SainT",

--- a/bucket/saint.json
+++ b/bucket/saint.json
@@ -1,0 +1,32 @@
+{
+    "version": "2.40",
+    "description": "SainT is a Windows based cycle accurate ATARI-ST emulator",
+    "homepage": "http://leonard.oxg.free.fr/SainT/saint.html",
+    "license": "",
+    "url": "http://leonard.oxg.free.fr/SainT/SainT240.zip",
+    "hash": "a30c15f485bcc7ada635a5eb1654ff5cf805da8d141a1b64d4e83a26d609b0fa",
+    "extract_dir": "SainT",
+    "bin": [
+        "SainT.exe",
+        "Dir2Msa\\dir2msa.exe"
+    ],
+    "shortcuts": [
+        [
+            "SainT.exe",
+            "SainT Atari-ST Emulator"
+        ]
+    ],
+    "persist": [
+        "SaintT.ini",
+        "MemoryShot",
+        "Tos102uk.img",
+        "tos106fr.img"
+    ],
+    "checkver": {
+        "url": "http://leonard.oxg.free.fr/SainT/versions.txt",
+        "re": "^([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "http://leonard.oxg.free.fr/SainT/SainT$cleanVersion.zip"
+    }
+}


### PR DESCRIPTION
SainT is a Windows based cycle accurate ATARI-ST emulator, written by James Boulton and Arnaud Carré.