### PR TITLE
aranym: Add version 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ scoop update
 
 scoop install a7800
 scoop install altirra
+scoop install aranym
 scoop install asap
 scoop install atari800
 scoop install handy
@@ -33,6 +34,7 @@ scoop install xformer
 |-|-|-|
 | [a7800](https://github.com/7800-devtools/a7800) | 8-bit console | An Atari 7800 emulator |
 | [altirra](http://www.virtualdub.org/altirra.html) | 8-bit computer | Very accurate 8-bit Atari computer emulator |
+| [aranym](https://aranym.github.io) | 32-bit OS | ARAnyM is a VM (similar to VirtualBox or Bochs) designed for running 32-bit Atari ST/TT/Falcon OSes |
 | [asap](http://asap.sourceforge.net) | POKEY chip | A player of Atari 8-bit chiptunes for modern computers. Emulates POKEY sound chip and the 6502 cpu |
 | [atari800](https://atari800.github.io) | 8-bit computer | Very portable 8-bit Atari computer emulator |
 | [handy](http://handy.sourceforge.net) | 8-bit handheld | Legacy emulator of Lynx handheld from Atari (codename Handy) |

--- a/bucket/aranym.json
+++ b/bucket/aranym.json
@@ -1,0 +1,35 @@
+{
+    "version": "1.1.0",
+    "description": "ARAnyM is a VM designed and developed for running 32-bit Atari ST/TT/Falcon operating systems (TOS, FreeMiNT, MagiC and Linux-m68k) and TOS/GEM applications on any kind of hardware",
+    "homepage": "https://aranym.github.io/",
+    "license": "GPL-2.0-only",
+    "url": "https://github.com/aranym/aranym/releases/download/ARANYM_1_1_0/aranym-1.1.0-cygwin-i386-sdl2-setup.exe#/dl.7z",
+    "hash": "ac02c8aaa7b4404b8fde6d692fb314781c19f2a2a446f7cecd1c3e5e42d187aa",
+    "pre_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\uninstall-aranym.exe\" -Force -Recurse",
+    "bin": [
+        "aranym.exe",
+        "aranym-jit.exe",
+        "aranym-mmu.exe"
+    ],
+    "shortcuts": [
+        [
+            "aranym.exe",
+            "Aranym"
+        ],
+        [
+            "aranym-jit.exe",
+            "Aranym (JIT)"
+        ],
+        [
+            "aranym-mmu.exe",
+            "Aranym (MMU)"
+        ]
+    ],
+    "checkver": {
+        "url": "https://github.com/aranym/aranym/releases",
+        "regex": "version ([\\d.]+) released"
+    },
+    "autoupdate": {
+        "url": "https://github.com/aranym/aranym/releases/download/ARANYM_$underscoreVersion/aranym-$version-cygwin-i386-sdl2-setup.exe#/dl.7z"
+    }
+}


### PR DESCRIPTION
ARAnyM is a software virtual machine (similar to VirtualBox or Bochs) designed and developed for running 32-bit Atari ST/TT/Falcon operating systems (TOS, FreeMiNT, MagiC and Linux-m68k) and TOS/GEM applications on any kind of hardware - be it an IBM clone (read it as "PC" :-), an Apple, an Unix server, a graphics workstation or even a portable computer.