### PR TITLE
bupsystem: Add version 0.9.6.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ scoop install altirra
 scoop install aranym
 scoop install asap
 scoop install atari800
+scoop install bupsystem
 scoop install emu7800
 scoop install handy
 scoop install hatari
@@ -38,6 +39,7 @@ scoop install xformer
 | [aranym](https://aranym.github.io) | 32-bit OS | ARAnyM is a VM (similar to VirtualBox or Bochs) designed for running 32-bit Atari ST/TT/Falcon OSes |
 | [asap](http://asap.sourceforge.net) | POKEY chip | A player of Atari 8-bit chiptunes for modern computers. Emulates POKEY sound chip and the 6502 cpu |
 | [atari800](https://atari800.github.io) | 8-bit computer | Very portable 8-bit Atari computer emulator |
+| [bupsystem](http://tailchao.com/BupSystem/) | 8-bit console | Closed source Atari 7800 ProSystem emulator |
 | [emu7800](https://emu7800.github.io/) | 8-bit console | Emulates the Atari 7800 ProSystem video game console |
 | [handy](http://handy.sourceforge.net) | 8-bit handheld | Legacy emulator of Lynx handheld from Atari (codename Handy) |
 | [hatari](https://hatari.tuxfamily.org) | 16-bit computer | A very nice emulator of Atari-ST, TT, Falcon |

--- a/bucket/bupsystem.json
+++ b/bucket/bupsystem.json
@@ -1,0 +1,22 @@
+{
+    "version": "0.9.6.4",
+    "description": "Closed source Atari 7800 ProSystem emulator",
+    "homepage": "http://tailchao.com/BupSystem/",
+    "license": "Freeware",
+    "url": "http://tailchao.com/BupSystem/BupSystem_v0-9-6-4.zip",
+    "hash": "549062f037e59d9e57862d1846cdf2cc1b04404eb3f2f99f21e729aaee0ce813",
+    "shortcuts": [
+        [
+            "BupSystem.exe",
+            "BupSystem (Atari 7800)"
+        ]
+    ],
+    "checkver": {
+        "url": "http://tailchao.com/BupSystem/",
+        "re": "BupSystem ([\\d.]+)"
+
+    },
+    "autoupdate": {
+        "url": "http://tailchao.com/BupSystem/BupSystem_v$dashVersion.zip"
+    }
+}


### PR DESCRIPTION
Closed source Atari 7800 console emulator.