### PR TITLE
fix: Adhere to manifest schema

### DIFF
--- a/bucket/bupsystem.json
+++ b/bucket/bupsystem.json
@@ -13,7 +13,7 @@
     ],
     "checkver": {
         "url": "http://tailchao.com/BupSystem/",
-        "re": "BupSystem ([\\d.]+)"
+        "regex": "BupSystem ([\\d.]+)"
 
     },
     "autoupdate": {

--- a/bucket/handy.json
+++ b/bucket/handy.json
@@ -21,7 +21,7 @@
     ],
     "checkver": {
         "url": "https://sourceforge.net/projects/handy/rss?path=/handy",
-        "re": "Handy-([\\d.]+)\\.zip"
+        "regex": "Handy-([\\d.]+)\\.zip"
     },
     "autoupdate": {
         "url": "https://downloads.sourceforge.net/project/handy/handy/Handy%20$version/Handy-$version.zip"

--- a/bucket/saint.json
+++ b/bucket/saint.json
@@ -24,7 +24,7 @@
     ],
     "checkver": {
         "url": "http://leonard.oxg.free.fr/SainT/versions.txt",
-        "re": "^([\\d.]+)"
+        "regex": "^([\\d.]+)"
     },
     "autoupdate": {
         "url": "http://leonard.oxg.free.fr/SainT/SainT$cleanVersion.zip"

--- a/bucket/steemsse.json
+++ b/bucket/steemsse.json
@@ -31,7 +31,7 @@
     },
     "checkver": {
         "url": "https://sourceforge.net/projects/steemsse/rss",
-        "re": "/Steem\\.SSE\\.([\\d.]+)\\.Win64\\.D3D\\.R32\\.zip"
+        "regex": "/Steem\\.SSE\\.([\\d.]+)\\.Win64\\.D3D\\.R32\\.zip"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
It seems like 're' is no longer passing validation. Rewrite to 'regex'